### PR TITLE
Add a devenv

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -28,3 +28,6 @@ install_data(
   'studio.planetpeanut.Bobby.gschema.xml',
   install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
 )
+gnome.post_install(glib_compile_schemas: true)
+gnome.compile_schemas(depend_files: files('studio.planetpeanut.Bobby.gschema.xml'))
+devenv.append('GSETTINGS_SCHEMA_DIR', meson.current_build_dir())

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,9 @@ dependency('glib-2.0')
 dependency('gtk4')
 dependency('libadwaita-1')
 
+devenv = environment()
+devenv.prepend('PATH', meson.current_build_dir())
+meson.add_devenv(devenv)
 
 subdir('data')
 subdir('data/icons')


### PR DESCRIPTION
This allows you to run from the build directory without installing.

This required compiling the gschmeas during build, which is a good for finding errors right away.

Also added the top level build directory to the PATH environment variable as the cargo stuff doesn't seem to do that.

This all makes it possible for you to run `ninja && meson devenv bobby` from the build directory and it'll work as if it was installed.